### PR TITLE
Use today instead of a hardcoded date

### DIFF
--- a/paper.md
+++ b/paper.md
@@ -1,7 +1,7 @@
 ---
 title: mdspan.at()
 document: P3383R0
-date: 2023-12-11
+date: today
 audience:
 - Library Evolution Working Group (LEWG)
 - SG23 Safety and Security


### PR DESCRIPTION
This will allow to have the date when the paper was generated instead of having to update it manually.